### PR TITLE
Introduced github-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+### Description of the issue
+Describe the issue you are experiencing.
+
+### Issue-Type (put a `x` sign in the square brackets)
+- [ ] bug report
+- [ ] feature request
+- [ ] Documentation improvement
+- [ ] Other
+
+### Checklist
+- [ ] Running latest version of code.
+- [ ] This issue has not been reported earlier.
+
+### Your environment
+* OS
+* Python Version
+* Release tag/commit of the code
+
+### Expected behaviour
+What should happen?
+
+### Actual behaviour
+What is actually happening?
+
+### Steps to reproduce
+
+### Any extra info ( for eg. code snippet to reproduce, logs, screenshots etc. )
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Proposed changes in this pull request
+
+### Type (put an `x` where ever applicable)
+- [ ] Bug fix: Link to the issue
+- [ ] Feature (Non-breaking change)
+- [ ] Feature (Breaking change)
+- [ ] Documentation Improvement
+- [ ] Other
+
+### Checklist
+Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)
+
+- [ ] All the tests are passing after the introduction of new changes.
+- [ ] Added tests respective to the part of code I have written.
+- [ ] Added proper documentation where ever applicable (in code and README.md).
+
+### Optional extra information
+


### PR DESCRIPTION
Once merged, this is how it would look like:

### Proposed changes in this pull request
Introduced github templates for issue/pull-request

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [x] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information
N/A