### PR TITLE
deps: unpin psycopg and do not use binary version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         ],
     },
     install_requires=[
-        "psycopg2-binary==2.8.6"
+        "psycopg2"
     ],
     license="Apache 2.0",
     name="aiven-db-migrate",


### PR DESCRIPTION
This exact version (and also binary package) is quite fresh and is not available in the environment where we run migration.
Also I would not be so strict about version, if we pin it, it should be at least 2.7.7 and also not a binary.