### PR TITLE
honour connect_timeout and PGCONNECT_TIMEOUT [BF-25]

### DIFF
--- a/test/test_pg_cluster.py
+++ b/test/test_pg_cluster.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from aiven_db_migrate.migrate.pgmigrate import PGCluster
+from multiprocessing import Process
+from test.conftest import PGRunner
+from typing import Tuple
+
+import os
+import pytest
+import signal
+import time
+
+
+def test_interruptible_queries(pg_cluster: PGRunner):
+    def wait_and_interrupt():
+        time.sleep(1)
+        os.kill(os.getppid(), signal.SIGINT)
+
+    cluster = PGCluster(conn_info=pg_cluster.conn_info())
+    interuptor = Process(target=wait_and_interrupt)
+    interuptor.start()
+    start_time = time.monotonic()
+    with pytest.raises(KeyboardInterrupt):
+        cluster.c("select pg_sleep(100)")
+    assert time.monotonic() - start_time < 2
+    interuptor.join()


### PR DESCRIPTION
The wait_select callback previously installed to enable Ctrl+C during long queries was breaking configurable connection timeout :
https://github.com/psycopg/psycopg2/issues/944

This was replaced with a more visible async connection and a manual call to a custom wait_select with support for timeout.

The timeout mimics default libpq behavior and reads the connect_timeout connection parameter with a fallback on PGCONNECT_TIMEOUT environment variable (and a default of 0: no timeout).

A secondary benefit is to allow importing PGMigrate inside another project without PGMigrate altering the global set_wait_callback.

### Proposed changes in this pull request

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

