### PR TITLE
use any pgdump between source and target version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This installs console scripts which have the same interface as the library modul
 ## PostgreSQL
 
 Requirements:
- * `pg_dump`: from the PostgreSQL version where migrating from
+ * `pg_dump`: from any PostgreSQL version between the source and target versions
  * `psql`: any modern version should work
 
 Run library module:

--- a/aiven_db_migrate/migrate/pgmigrate.py
+++ b/aiven_db_migrate/migrate/pgmigrate.py
@@ -1129,7 +1129,9 @@ class PGMigrate:
                 raise PGMigrateValidationFailedError("Migrating to the same server is not supported")
             if self.source.version > self.target.version:
                 raise PGMigrateValidationFailedError("Migrating to older PostgreSQL server version is not supported")
-            self.pgbin = find_pgbin_dir(str(self.source.version))
+            # pgdump cannot be older than the source version, cannot be newer than the target version
+            # but it can be newer than the source version: source <= pgdump <= target
+            self.pgbin = find_pgbin_dir(str(self.source.version), max_pgversion=str(self.target.version))
             self._check_databases()
             self._check_pg_lang()
             self._check_pg_ext()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,18 +1,75 @@
 # Copyright (c) 2020 Aiven, Helsinki, Finland. https://aiven.io/
 
 from aiven_db_migrate.migrate.pgutils import find_pgbin_dir, validate_pg_identifier_length
+from pathlib import Path
 from test.utils import random_string
 
 import pytest
+import tempfile
 
 
-def test_find_pgbin_dir():
-    for pgversion in ("9.5", "9.6", "10", "10.4", "11", "11.7", "12", "12.2"):
+def test_pgbin_dir_exists_for_supported_versions():
+    for pgversion in ("9.5", "9.6", "10", "10.4", "11", "11.7", "12", "12.2", "13"):
         find_pgbin_dir(pgversion)
     for pgversion in ("12345", "12345.6"):
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError, match=f"Couldn't find bin dir for pg version '{pgversion}'.*") as err:
             find_pgbin_dir(pgversion)
-        assert f"Couldn't find pg version '{pgversion}' bin dir" in str(err)
+
+
+@pytest.mark.parametrize("pg_dir", ["pgsql-12", "pgsql-12.4", "lib/postgresql/12", "lib/postgresql/12.4"])
+def test_find_pgbin_dir(pg_dir):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        usr_dir = Path(temp_dir)
+        pgbin_12 = usr_dir / pg_dir / "bin"
+        pgbin_12.mkdir(parents=True)
+        with pytest.raises(ValueError):
+            find_pgbin_dir("10", usr_dir=usr_dir)
+        with pytest.raises(ValueError):
+            find_pgbin_dir("10", max_pgversion="11", usr_dir=usr_dir)
+        assert find_pgbin_dir("10", max_pgversion="12", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("10", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("12", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("12", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("12.2", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("12.2", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
+        with pytest.raises(ValueError):
+            assert find_pgbin_dir("13", usr_dir=usr_dir)
+        with pytest.raises(ValueError):
+            assert find_pgbin_dir("13", max_pgversion="14", usr_dir=usr_dir)
+
+
+@pytest.mark.parametrize("pg_dir", ["pgsql-9.6", "pgsql-9.6.33", "lib/postgresql/9.6", "lib/postgresql/9.6.33"])
+def test_find_pgbin_dir_version_9(pg_dir):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        usr_dir = Path(temp_dir)
+        pgbin_96 = usr_dir / pg_dir / "bin"
+        pgbin_96.mkdir(parents=True)
+        with pytest.raises(ValueError):
+            find_pgbin_dir("9.4", usr_dir=usr_dir)
+        with pytest.raises(ValueError):
+            find_pgbin_dir("9.4", max_pgversion="9.5", usr_dir=usr_dir)
+        assert find_pgbin_dir("9.4", max_pgversion="9.6", usr_dir=usr_dir) == pgbin_96
+        assert find_pgbin_dir("9.4", max_pgversion="10", usr_dir=usr_dir) == pgbin_96
+        assert find_pgbin_dir("9.6", usr_dir=usr_dir) == pgbin_96
+        assert find_pgbin_dir("9.6", max_pgversion="10", usr_dir=usr_dir) == pgbin_96
+        assert find_pgbin_dir("9.6.22", usr_dir=usr_dir) == pgbin_96
+        assert find_pgbin_dir("9.6.22", max_pgversion="10", usr_dir=usr_dir) == pgbin_96
+        with pytest.raises(ValueError):
+            find_pgbin_dir("9.7", usr_dir=usr_dir)
+        with pytest.raises(ValueError):
+            find_pgbin_dir("9.7", max_pgversion="10", usr_dir=usr_dir)
+
+
+def test_find_pgbin_dir_prefers_oldest():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        usr_dir = Path(temp_dir)
+        pgbin_12 = usr_dir / "pgsql-12/bin"
+        pgbin_12.mkdir(parents=True)
+        pgbin_13 = usr_dir / "pgsql-13/bin"
+        pgbin_13.mkdir(parents=True)
+        assert find_pgbin_dir("10", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("11", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
+        assert find_pgbin_dir("12", max_pgversion="13", usr_dir=usr_dir) == pgbin_12
 
 
 def test_validate_pg_identifier_length():


### PR DESCRIPTION
Instead of only looking for pgdump in a bin dir exactly matching the
source database version, look for any pgdump that is equal or newer
than the source version and equal or older than the target version.

### Proposed changes in this pull request

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

