### PR TITLE
add --no-replicate-extension-tables to skip extension tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ can be used together with `--stop-replication` to clean up all created pub/sub o
 With `--validate` only best effort validation is run. This checks e.g. PL/pgSQL languages, extensions etc. installed
 in source are also installed/available in target.
 
+Use `--no-replicate-extension-tables` to skip extension tables.  By default it attempts to replicate all extension tables during logical replication.
+
 ### API example
 
 Migrating from AWS RDS to Aiven for PostgreSQL. Logical replication is enabled in source AWS RDS PostgreSQL

--- a/test/test_pg_cluster.py
+++ b/test/test_pg_cluster.py
@@ -3,7 +3,6 @@ from aiven_db_migrate.migrate.pgmigrate import PGCluster
 from distutils.version import LooseVersion
 from multiprocessing import Process
 from test.conftest import PGRunner
-from typing import Tuple
 
 import os
 import pytest

--- a/test/test_table_filtering.py
+++ b/test/test_table_filtering.py
@@ -35,7 +35,7 @@ def test_extension_table_filtering(
     )
     for t in tables:
         pg_mig.source.c(f"CREATE TABLE {t} (foo int)", return_rows=0, dbname=db_name)
-    pg_mig.source.c(f"CREATE EXTENSION postgis CASCADE", return_rows=0, dbname=db_name)
+    pg_mig.source.c("CREATE EXTENSION postgis CASCADE", return_rows=0, dbname=db_name)
     # pylint: disable=protected-access
     pg_mig.source._set_db(dbname=db_name)
     # pylint: enable=protected-access
@@ -63,7 +63,7 @@ def test_extension_table_filtering(
     )
     for t in tables:
         pg_mig.source.c(f"CREATE TABLE {t} (foo int)", return_rows=0, dbname=other_db_name)
-    pg_mig.source.c(f"CREATE EXTENSION postgis CASCADE", return_rows=0, dbname=other_db_name)
+    pg_mig.source.c("CREATE EXTENSION postgis CASCADE", return_rows=0, dbname=other_db_name)
     # pylint: disable=protected-access
     pg_mig.source._set_db(dbname=other_db_name)
     # pylint: enable=protected-access

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -12,7 +12,7 @@ def test_pgbin_dir_exists_for_supported_versions():
     for pgversion in ("9.5", "9.6", "10", "10.4", "11", "11.7", "12", "12.2", "13"):
         find_pgbin_dir(pgversion)
     for pgversion in ("12345", "12345.6"):
-        with pytest.raises(ValueError, match=f"Couldn't find bin dir for pg version '{pgversion}'.*") as err:
+        with pytest.raises(ValueError, match=f"Couldn't find bin dir for pg version '{pgversion}'.*"):
             find_pgbin_dir(pgversion)
 
 


### PR DESCRIPTION
### Proposed changes in this pull request

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
https://github.com/aiven/aiven-db-migrate/issues/10

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [N/A] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information
currently `--replicate-extension-tables` is always True whether this option is provided in CLI or not
```
        action="store_true",
        default=True,
```
adding `--no-replicate-extension-tables` to allow skipping replicate extension tables.