### PR TITLE
add check for maximum databases size to migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Use `--no-replicate-extension-tables` to skip extension tables.  By default it a
 
 With `--force-method` you can specify if you wish to use either replication or dump method. Otherwise the most suitable method is chosen automatically.
 
+Using `--dbs-max-total-size` together with `--validate` you can check if the size of the source database in below some threshold.
+
 ### API example
 
 Migrating from AWS RDS to Aiven for PostgreSQL. Logical replication is enabled in source AWS RDS PostgreSQL

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from aiven_db_migrate.migrate.pgutils import find_pgbin_dir
 from contextlib import contextmanager
+from copy import copy
 from datetime import datetime
 from distutils.version import LooseVersion
 from pathlib import Path
@@ -423,7 +424,9 @@ def generate_fixtures():
         assert version in SUPPORTED_PG_VERSIONS, f"Supported pg versions are: {SUPPORTED_PG_VERSIONS}"
         pg_target_versions.append(version)
     else:
-        pg_target_versions = SUPPORTED_PG_VERSIONS
+        # We do not support PG 9.5 as target
+        pg_target_versions = copy(SUPPORTED_PG_VERSIONS)
+        pg_target_versions.remove("9.5")
 
     for source in pg_source_versions:
         name_prefix = "pg{}".format(source.replace(".", ""))

--- a/test/test_db_size_check.py
+++ b/test/test_db_size_check.py
@@ -1,0 +1,47 @@
+from aiven_db_migrate.migrate.pgmigrate import PGMigrate
+from test.conftest import PGRunner
+from test.utils import random_string
+from typing import Tuple
+
+import psycopg2
+import pytest
+
+
+def test_db_size(pg_source_and_target_replication: Tuple[PGRunner, PGRunner]):
+    source, target = pg_source_and_target_replication
+
+    db_name = random_string(6)
+    other_db_name = random_string(6)
+
+    source.create_db(dbname=db_name)
+    source.create_db(dbname=other_db_name)
+
+    pg_mig = PGMigrate(
+        source_conn_info=source.super_conn_info(),
+        target_conn_info=target.super_conn_info(),
+        verbose=True,
+    )
+
+    # Create few tables and insert some data
+    tables = [f'table_{i}' for i in range(4)]
+    for dbname in {db_name, other_db_name}:
+        with source.cursor(dbname=dbname) as c:
+            for t in tables:
+                c.execute(f"DROP TABLE IF EXISTS {t}")
+                c.execute(f"CREATE TABLE {t} (foo INT)")
+                c.execute(f"INSERT INTO {t} (foo) VALUES (1), (2), (3)")
+
+    size = pg_mig.source.get_size(dbname=db_name, only_tables=[])
+    assert size == 0
+
+    size = pg_mig.source.get_size(dbname=db_name)
+    assert size >= 0  # returns slightly different values per pg version
+
+    size = pg_mig.source.get_size(dbname=db_name, only_tables=tables)
+    assert size == 32768
+
+    size = pg_mig.source.get_size(dbname=db_name, only_tables=tables[:1])
+    assert size == 8192
+
+    with pytest.raises(psycopg2.OperationalError):
+        size = pg_mig.source.get_size(dbname="notfound")

--- a/test/test_migrate_checks.py
+++ b/test/test_migrate_checks.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+
+from aiven_db_migrate.migrate.errors import PGMigrateValidationFailedError
+from aiven_db_migrate.migrate.pgmigrate import PGMigrate
+from test.conftest import PGRunner
+from test.utils import random_string
+from typing import Tuple
+from unittest.mock import patch
+
+import pytest
+
+
+def test_dbs_max_total_size_check(pg_source_and_target: Tuple[PGRunner, PGRunner]):
+    source, target = pg_source_and_target
+    dbnames = {random_string() for _ in range(3)}
+
+    for dbname in dbnames:
+        source.create_db(dbname=dbname)
+        target.create_db(dbname=dbname)
+
+    # This DB seems to be created outside the tests
+    dbnames.add("postgres")
+
+    # Create few tables and insert some data
+    tables = [f'table_{i}' for i in range(4)]
+    for dbname in dbnames:
+        with source.cursor(dbname=dbname) as c:
+            for t in tables:
+                c.execute(f"DROP TABLE IF EXISTS {t}")
+                c.execute(f"CREATE TABLE {t} (foo INT)")
+                c.execute(f"INSERT INTO {t} (foo) VALUES (1), (2), (3)")
+
+    pg_mig = PGMigrate(
+        source_conn_info=source.conn_info(),
+        target_conn_info=target.conn_info(),
+        createdb=False,
+        verbose=True,
+    )
+
+    with patch(
+        "aiven_db_migrate.migrate.pgmigrate.PGMigrate._check_database_size", side_effect=pg_mig._check_database_size
+    ) as mock_db_size_check:
+        # DB size check is not run
+        pg_mig.validate()
+        mock_db_size_check.assert_not_called()
+
+        mock_db_size_check.reset_mock()
+
+        # DB size check with max size of zero
+        with pytest.raises(PGMigrateValidationFailedError) as e:
+            pg_mig.validate(dbs_max_total_size=0)
+        assert "Databases do not fit to the required maximum size" in str(e)
+        mock_db_size_check.assert_called_once_with(max_size=0)
+
+        mock_db_size_check.reset_mock()
+
+        # DB size check with enough size
+        pg_mig.validate(dbs_max_total_size=1073741824)
+        mock_db_size_check.assert_called_once_with(max_size=1073741824)
+
+    # Test with DB name filtering
+    pg_mig = PGMigrate(
+        source_conn_info=source.conn_info(),
+        target_conn_info=target.conn_info(),
+        createdb=False,
+        verbose=True,
+        filtered_db=",".join(dbnames),
+    )
+
+    with patch(
+        "aiven_db_migrate.migrate.pgmigrate.PGMigrate._check_database_size", side_effect=pg_mig._check_database_size
+    ) as mock_db_size_check:
+        # Should pass as all DBs are filtered out from size calculations
+        pg_mig.validate(dbs_max_total_size=0)
+        mock_db_size_check.assert_called_once_with(max_size=0)
+
+    # Test with table filtering
+
+    # Include all tables in "skip_tables"
+    pg_mig = PGMigrate(
+        source_conn_info=source.conn_info(),
+        target_conn_info=target.conn_info(),
+        createdb=False,
+        verbose=True,
+        skip_tables=tables,  # skip all tables
+    )
+
+    with patch(
+        "aiven_db_migrate.migrate.pgmigrate.PGMigrate._check_database_size", side_effect=pg_mig._check_database_size
+    ) as mock_db_size_check:
+        # Should pass as all tables are filtered out from size calculations
+        pg_mig.validate(dbs_max_total_size=0)
+        mock_db_size_check.assert_called_once_with(max_size=0)
+
+    # Only the first table is included
+    pg_mig = PGMigrate(
+        source_conn_info=source.conn_info(),
+        target_conn_info=target.conn_info(),
+        createdb=False,
+        verbose=True,
+        with_tables=tables[:1],  # include only one table
+    )
+    with patch(
+        "aiven_db_migrate.migrate.pgmigrate.PGMigrate._check_database_size", side_effect=pg_mig._check_database_size
+    ) as mock_db_size_check:
+        # This fails as one table is included in check and it should have data
+        with pytest.raises(PGMigrateValidationFailedError) as e:
+            pg_mig.validate(dbs_max_total_size=0)
+        assert "Databases do not fit to the required maximum size" in str(e)
+        mock_db_size_check.assert_called_once_with(max_size=0)
+
+        # Should easily fit
+        pg_mig.validate(dbs_max_total_size=1073741824)


### PR DESCRIPTION
### Proposed changes in this pull request

Adds possibility for checking that the size of the source database is under some limit. This can e.g. used with `--validate` by adding `--dbs-max-total-size <max_size>` to the `pg_migrate` command.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

