### PR TITLE
add --pgbin support allows pg_dump from  non-/usr/ directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ $ pg_migrate -h
 Migrating is supported to the same or newer PostgreSQL version starting from PostgreSQL 9.5 to PostgreSQL 14.
 Migrating to older version is not supported.
 
+By default it searches `pg_dump` under `/usr/`, when using PostgreSQL installs on different directory such as on Mac, use `--pgbin` parameter to define PostgreSQL home directory. e,g,
+```
+--pgbin /Applications/Postgres.app/Contents/Versions/14/bin
+```
+
 Supports regular data dump (`pg_dump`) and [logical replication](https://www.postgresql.org/docs/current/logical-replication.html) (PostgreSQL 10 or newer).
 In case that logical replication is not available or privileges/requirements are missing migrating falls back to
 data dump.


### PR DESCRIPTION
add PGHOMEDIR support allows pg_dump from  non-/usr/ directories
partially addressed the issues on Mac: https://github.com/aiven/aiven-db-migrate/issues/31

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

