### PR TITLE
pgmigrate: add warnings when large objects present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ __pycache__
 build
 dist
 .venv*
+venv
+.vscode/*
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ PGMigrateResult(pg_databases={'rdsadmin': {'dbname': 'rdsadmin', 'message': 'FAT
  * superuser or superuser-like privileges, such as `rds_replication` role in AWS RDS, in both source and target
  * [AWS RDS additional settings/info](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.FeatureSupport.LogicalReplication)
 
+#### Warning
+
+⚠️ Large objects are [unable to be replicated using logical replication](https://www.postgresql.org/docs/15/logical-replication-restrictions.html), up to and including PostgreSQL 15.
+
 ### Schemas
  * schemas are migrated without object ownership; the user used for migration is given all object ownership
  * NOTE: schema changes break logical replication


### PR DESCRIPTION
### Proposed changes in this pull request

Large objects are not compatible with logical replication as of writing
(https://www.postgresql.org/docs/15/logical-replication-restrictions.html).

Add some warning output if we detect the presence of large objects, and
also update our docs to indicate this.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [X] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [X] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [X] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [X] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

