### PR TITLE
Update python versions [BF-2100]

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: pip install -r requirements-dev.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11" ]
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.7
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
 
     - name: Setup container
       run: sudo ./ci/install.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,10 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
 

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,5 +4,4 @@ force_alphabetical_sort = true
 combine_as_imports = true
 no_sections = true
 skip_glob =
-not_skip = __init__.py
 multi_line_output = 5

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ mypy: $(generated)
 	$(PYTHON) -m mypy $(PYTHON_SOURCE_DIRS)
 
 isort: $(generated)
-	$(PYTHON) -m isort --recursive $(PYTHON_SOURCE_DIRS)
+	$(PYTHON) -m isort $(PYTHON_SOURCE_DIRS)
 
 yapf: $(generated)
 	$(PYTHON) -m yapf --parallel --recursive --in-place $(PYTHON_SOURCE_DIRS)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ such as `pg_dumpall`, not useful when migrating database to/from service provide
 
 Currently this tool supports only PostgreSQL but we aim to add support for other databases, such as MySQL.
 
-Requires Python 3.5 or newer.
+Requires Python 3.9 or newer.
 
 ## Usage
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global configuration
 
 [mypy]
-python_version = 3.7
+python_version = 3.9
 warn_redundant_casts = True
 
 # Module based overrides to disable errors on legacy code

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-flake8==3.8.4
-isort==5.6.4
-mypy==0.790
-psycopg2==2.8.6
-pylint==2.6.0
-pytest==6.1.2
-yapf==0.30.0
+flake8==6.0.0
+isort==5.12.0
+mypy==1.3.0
+psycopg2==2.9.6
+pylint==2.17.4
+pytest==7.3.1
+yapf==0.33.0

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         "psycopg2"
     ],
+    python_requires=">=3.9",
     license="Apache 2.0",
     name="aiven-db-migrate",
     packages=find_packages(exclude=["test"]),
@@ -34,9 +35,8 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
Python versions are now in sync between the `README`, the CI and the classifiers.

New:
- `setup.py` now has 3.9+.

To be noted:
- Python 3.11 binaries are available since `psycopg2>=2.9.5`. The version pinning is only for the CI. Setuptools still picks the latest compatible version for the platform (unchanged).

[BF-2100]

### Proposed changes in this pull request

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [x] Documentation Improvement
- [x] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information



[BF-2100]: https://aiven.atlassian.net/browse/BF-2100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ