### PR TITLE
Update version string to a PEP-440 compatible one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ generated = aiven_db_migrate/migrate/version.py
 all: $(generated)
 
 aiven_db_migrate/migrate/version.py:
-	echo "__version__ = \"$(shell git describe)\"" > $@
+	echo "__version__ = \"$(shell git describe | awk -F- '{ printf "%s",$$1 } length($$2) != 0 {printf ".dev%s",$$2} length($$3) != 0 { printf "+%s",$$3 }')\"" > $@
 
 build-dep-fedora:
 	sudo dnf -y install --best --allowerasing \


### PR DESCRIPTION
### Proposed changes in this pull request

setuptools > 66 requires PEP-440 compatible version strings. 

The version string is converted from *git describe* format (`<version>-<num>-<sha>`) to `<version>.dev<num>+<sha>` format.

Addresses the issue #51.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [X] All the tests are passing after the introduction of new changes.
- [N/A] Added tests respective to the part of code I have written.
- [N/A] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

