### PR TITLE
Added --skip-db-version-check flag

### DIFF
--- a/aiven_db_migrate/migrate/pgutils.py
+++ b/aiven_db_migrate/migrate/pgutils.py
@@ -21,6 +21,7 @@ def find_pgbin_dir(pgversion: str, *, max_pgversion: Optional[str] = None, usr_d
     """
     min_version = LooseVersion(pgversion).version
     max_version = min_version if max_pgversion is None else LooseVersion(max_pgversion).version
+    max_version = max(max_version, min_version)
     max_parts = 1
     candidates = []
     search_scopes = [(usr_dir, r"pgsql-([0-9]+(\.[0-9]+)*)"), (usr_dir / "lib/postgresql", r"([0-9]+(\.[0-9]+)*)")]


### PR DESCRIPTION
1. Added new flag `--skip-db-version-check` which allow to skip PG version check between source and target.
2. Creating `aiven_extras` extension can lead to `psycopg2.NotSupportedError` - added its handling. 