### PR TITLE
Change the prefix used to name db objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Databases:
 ```
 
 By default logical replication is left running and the created pub/sub objects need to be cleaned up once workloads have been
-moved to the new server. Objects created by this tool are named like `aiven_db_migrate_<dbname>_<sub|pub|slot>`.
+moved to the new server. Objects created by this tool are named like `managed_db_migrate_<dbname>_<sub|pub|slot>`.
 
 Starting from the target (using `aiven-extras` extension), get first the subscription name:
 ```
@@ -100,7 +100,7 @@ defaultdb= > SELECT * FROM aiven_extras.pg_list_all_subscriptions();
 ```
 and then drop it:
 ```
-defaultdb= > SELECT * FROM aiven_extras.pg_drop_subscription('aiven_db_migrate_defaultdb_sub');
+defaultdb= > SELECT * FROM aiven_extras.pg_drop_subscription('managed_db_migrate_defaultdb_sub');
 ```
 
 Note that with `aiven-extras` dropping subscription in target also drops replication slot in source (`dblink`).
@@ -111,13 +111,13 @@ defaultdb=> SELECT * FROM pg_publication;
 ```
 and then drop it:
 ```
-defaultdb=> DROP PUBLICATION aiven_db_migrate_defaultdb_pub;
+defaultdb=> DROP PUBLICATION managed_db_migrate_defaultdb_pub;
 ```
 
 In case that `aiven-extras` is not used clean up replication slot too:
 ```
 defaultdb=> SELECT * FROM pg_replication_slots;
-defaultdb=> SELECT * FROM pg_drop_replication_slot('aiven_db_migrate_defaultdb_slot');
+defaultdb=> SELECT * FROM pg_drop_replication_slot('managed_db_migrate_defaultdb_slot');
 ```
 
 Using `--max-replication-lag` waits until replication lag in bytes is less than/equal to given max replication lag. This

--- a/aiven_db_migrate/migrate/pgmigrate.py
+++ b/aiven_db_migrate/migrate/pgmigrate.py
@@ -455,7 +455,7 @@ class PGSource(PGCluster):
 
     def create_publication(self, *, dbname: str, only_tables: Optional[List[str]] = None) -> str:
         mangled_name = self.mangle_db_name(dbname)
-        pubname = f"aiven_db_migrate_{mangled_name}_pub"
+        pubname = f"managed_db_migrate_{mangled_name}_pub"
         validate_pg_identifier_length(pubname)
 
         pub_options: Union[List[str], str]
@@ -499,7 +499,7 @@ class PGSource(PGCluster):
 
     def create_replication_slot(self, *, dbname: str) -> str:
         mangled_name = self.mangle_db_name(dbname)
-        slotname = f"aiven_db_migrate_{mangled_name}_slot"
+        slotname = f"managed_db_migrate_{mangled_name}_slot"
         validate_pg_identifier_length(slotname)
 
         self.log.info("Creating replication slot %r in database %r", slotname, dbname)
@@ -594,7 +594,7 @@ class PGTarget(PGCluster):
     """Target PostgreSQL cluster"""
     def create_subscription(self, *, conn_str: str, pubname: str, slotname: str, dbname: str) -> str:
         mangled_name = self.mangle_db_name(dbname)
-        subname = f"aiven_db_migrate_{mangled_name}_sub"
+        subname = f"managed_db_migrate_{mangled_name}_sub"
         validate_pg_identifier_length(subname)
 
         has_aiven_extras = self.has_aiven_extras(dbname=dbname)

--- a/test/test_table_filtering.py
+++ b/test/test_table_filtering.py
@@ -208,13 +208,13 @@ def test_replicate_filter_with(pg_source_and_target: Tuple[PGRunner, PGRunner], 
         for db in [db_name, other_db_name, "postgres"]:
             try:
                 with target.cursor(username=target.superuser, dbname=db, autocommit=True) as cur:
-                    cur.execute(f"ALTER SUBSCRIPTION aiven_db_migrate_{db}_sub DISABLE")
-                    cur.execute(f"DROP SUBSCRIPTION IF EXISTS aiven_db_migrate_{db}_sub CASCADE")
+                    cur.execute(f"ALTER SUBSCRIPTION managed_db_migrate_{db}_sub DISABLE")
+                    cur.execute(f"DROP SUBSCRIPTION IF EXISTS managed_db_migrate_{db}_sub CASCADE")
             except psycopg2.Error:
                 pass
             try:
                 pg_mig.source.cleanup(
-                    dbname=db, pubname=f"aiven_db_migrate_{db}_pub", slotname=f"aiven_db_migrate_{db}_slot"
+                    dbname=db, pubname=f"managed_db_migrate_{db}_pub", slotname=f"managed_db_migrate_{db}_slot"
                 )
             except:  # pylint: disable=bare-except
                 pass


### PR DESCRIPTION
### Proposed changes in this pull request
This renamed the prefix used to name migration related db objects from `aiven_db_migrate` to `managed_db_migrate`.

### Type (put an `x` wherever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [x] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

