### PR TITLE
Revert "Merge pull request #57 from aiven/ettanany-change-prefix-of-db-object-names"

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Databases:
 ```
 
 By default logical replication is left running and the created pub/sub objects need to be cleaned up once workloads have been
-moved to the new server. Objects created by this tool are named like `managed_db_migrate_<dbname>_<sub|pub|slot>`.
+moved to the new server. Objects created by this tool are named like `aiven_db_migrate_<dbname>_<sub|pub|slot>`.
 
 Starting from the target (using `aiven-extras` extension), get first the subscription name:
 ```
@@ -100,7 +100,7 @@ defaultdb= > SELECT * FROM aiven_extras.pg_list_all_subscriptions();
 ```
 and then drop it:
 ```
-defaultdb= > SELECT * FROM aiven_extras.pg_drop_subscription('managed_db_migrate_defaultdb_sub');
+defaultdb= > SELECT * FROM aiven_extras.pg_drop_subscription('aiven_db_migrate_defaultdb_sub');
 ```
 
 Note that with `aiven-extras` dropping subscription in target also drops replication slot in source (`dblink`).
@@ -111,13 +111,13 @@ defaultdb=> SELECT * FROM pg_publication;
 ```
 and then drop it:
 ```
-defaultdb=> DROP PUBLICATION managed_db_migrate_defaultdb_pub;
+defaultdb=> DROP PUBLICATION aiven_db_migrate_defaultdb_pub;
 ```
 
 In case that `aiven-extras` is not used clean up replication slot too:
 ```
 defaultdb=> SELECT * FROM pg_replication_slots;
-defaultdb=> SELECT * FROM pg_drop_replication_slot('managed_db_migrate_defaultdb_slot');
+defaultdb=> SELECT * FROM pg_drop_replication_slot('aiven_db_migrate_defaultdb_slot');
 ```
 
 Using `--max-replication-lag` waits until replication lag in bytes is less than/equal to given max replication lag. This

--- a/aiven_db_migrate/migrate/pgmigrate.py
+++ b/aiven_db_migrate/migrate/pgmigrate.py
@@ -106,7 +106,7 @@ class PGRole:
 
 class PGCluster:
     """PGCluster is a collection of databases managed by a single PostgreSQL server instance"""
-    DB_OBJECT_PREFIX = "managed_db_migrate"
+    DB_OBJECT_PREFIX = "aiven_db_migrate"
     conn_info: Dict[str, Any]
     _databases: Dict[str, PGDatabase]
     _params: Dict[str, str]

--- a/test/test_table_filtering.py
+++ b/test/test_table_filtering.py
@@ -208,8 +208,8 @@ def test_replicate_filter_with(pg_source_and_target: Tuple[PGRunner, PGRunner], 
         for db in [db_name, other_db_name, "postgres"]:
             try:
                 with target.cursor(username=target.superuser, dbname=db, autocommit=True) as cur:
-                    cur.execute(f"ALTER SUBSCRIPTION managed_db_migrate_{db}_sub DISABLE")
-                    cur.execute(f"DROP SUBSCRIPTION IF EXISTS managed_db_migrate_{db}_sub CASCADE")
+                    cur.execute(f"ALTER SUBSCRIPTION aiven_db_migrate_{db}_sub DISABLE")
+                    cur.execute(f"DROP SUBSCRIPTION IF EXISTS aiven_db_migrate_{db}_sub CASCADE")
             except psycopg2.Error:
                 pass
             try:


### PR DESCRIPTION
This reverts commit 136dcf83af59c8b9510342a3b8dcce4d5b7a168d, reversing changes made to 66bcb364daaa08f1c9d47c7b6647e4ecbad1b6cf.

### Proposed changes in this pull request

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
- [ ] Other

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).

### Optional extra information

