### PR TITLE
 logging improvements

### DIFF
--- a/test/test_migrate_checks.py
+++ b/test/test_migrate_checks.py
@@ -6,6 +6,7 @@ from test.utils import PGRunner, random_string
 from typing import Tuple
 from unittest.mock import MagicMock, patch
 
+import aiven_db_migrate.migrate.pgmigrate
 import pytest
 
 
@@ -130,7 +131,7 @@ def test_large_object_warnings(pg_source_and_target: Tuple[PGRunner, PGRunner]):
         verbose=True,
     )
 
-    pg_mig.log = MagicMock()
+    aiven_db_migrate.migrate.pgmigrate.logger = MagicMock()
 
     # Create a large object in the source
     with source.cursor(dbname=source.defaultdb) as cur:
@@ -141,6 +142,6 @@ def test_large_object_warnings(pg_source_and_target: Tuple[PGRunner, PGRunner]):
     ) as mock_lobs_check:
         pg_mig.validate()
         mock_lobs_check.assert_called_once()
-        pg_mig.log.warning.assert_called_with(
+        aiven_db_migrate.migrate.pgmigrate.logger.warning.assert_called_with(
             "Large objects detected: large objects are not compatible with logical replication: https://www.postgresql.org/docs/14/logical-replication-restrictions.html"
         )


### PR DESCRIPTION
This PR improves the behavior and logging of the `pg_dump | pg_restore` pipeline:

1. **Realtime stream handling**

   * Added threads to read `stderr` and `stdout` from `pg_restore`, and `stderr` from `pg_dump` in realtime.
   * Prevents buffer growth and delays.

2. **Structured log labels**

   * Each log line from `pg_dump` and `pg_restore` now has the following label:

     ```
     [<bin>(pid)][<dump_type>][<dbname>]
     ```

     * `bin` – `pg_dump` or `pg_restore`
     * `pid` – process ID
     * `dump_type` – schema dump (S) or data dump (D)
     * `dbname` – database name being processed
   * Example: `[pg_restore(206440)][S][defaultdb]`
   * `STDOUT` is logged at **INFO**, `STDERR` at **WARNING**.

3. **Migration ID**

   * Added a migration ID (in `log_format` right after the timestamp).
   * Present in all migration log entries, making it easier to trace logs across multiple runs.

4. **Unified logging**

   * Removed all `print` statements.
   * All output is now handled via the logging framework.
